### PR TITLE
Reduces larval accelerant purge rate from 3 to 1

### DIFF
--- a/code/modules/reagents/reagents/toxin.dm
+++ b/code/modules/reagents/reagents/toxin.dm
@@ -530,7 +530,7 @@
 	reagent_state = LIQUID
 	color = "#CF3600" // rgb: 207, 54, 0
 	purge_list = list(/datum/reagent/medicine)
-	purge_rate = 3
+	purge_rate = 1
 	overdose_threshold = REAGENTS_OVERDOSE
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
 	toxpwr = 0


### PR DESCRIPTION

## About The Pull Request

reduces the rate at which larval accelerant purges meds from 3 meds/tick to 1 med/tick

## Why It's Good For The Game

standing still for half a second and getting punished by having all of your meds removed in half a second isn't that great. 
## Changelog
:cl:
balance: reduced the rate at which larval accelerant purges meds from 3 to 1
/:cl:
