### PR TITLE
Change "sentinels stung" to  "neurotoxin sting was used" in roundend statistics

### DIFF
--- a/code/datums/gamemodes/game_mode.dm
+++ b/code/datums/gamemodes/game_mode.dm
@@ -394,7 +394,7 @@ GLOBAL_LIST_INIT(bioscan_locations, list(
 	if(GLOB.round_statistics.trap_holes)
 		dat += "[GLOB.round_statistics.trap_holes] holes for acid and huggers were made."
 	if(GLOB.round_statistics.sentinel_neurotoxin_stings)
-		dat += "[GLOB.round_statistics.sentinel_neurotoxin_stings] number of times Sentinels stung."
+		dat += "[GLOB.round_statistics.sentinel_neurotoxin_stings] number of times neurotoxin sting was used."
 	if(GLOB.round_statistics.defiler_defiler_stings)
 		dat += "[GLOB.round_statistics.defiler_defiler_stings] number of times Defilers stung."
 	if(GLOB.round_statistics.defiler_neurogas_uses)


### PR DESCRIPTION


## About The Pull Request

the game reported all uses of neuro sting as "number of times sentinel stung" in roundend statistics, I forgot to change it when I gave shrike and drone neuro sting
## Why It's Good For The Game

makes end of round statistics report it correctly due to more than just sentinel having neurotoxin sting

## Changelog
:cl:
fix: roundend statistic for times neuro sting used instead of times sentinels stung
/:cl:

